### PR TITLE
feat: 添加 WPS Agents 功能

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ OpenCode WPS — OpenCode AI 的 WPS Office 插件，在 WPS 中嵌入 AI 对话
 opencode-wps/    ──安装──▶  %APPDATA%\kingsoft\wps\jsaddons\opencode-wps_\
 wps-office-mcp/  ──安装──▶  ~/.config/opencode/opencode.json (MCP 配置)
 skills/          ──安装──▶  ~/.opencode/skills/
+agents/          ──安装──▶  ~/.config/opencode/agents/ + ~/.opencode/agents/
 ```
 
 **规则：**
@@ -20,7 +21,7 @@ skills/          ──安装──▶  ~/.opencode/skills/
 
 ## 关键命令
 ```bash
-node install-addons.js   # 一键安装全部组件（修改 skills 后必须运行）
+node install-addons.js   # 一键安装全部组件（修改 skills/agents 后必须运行）
 npm run build            # 编译 MCP 服务器 (cd wps-office-mcp && npm run build)
 npm run mcp:install      # 安装 MCP 依赖
 ```
@@ -32,19 +33,54 @@ opencode-wps/
 ├── wps-office-mcp/       # MCP 服务器 (TypeScript, 196 个工具)
 ├── skills/               # 4 个 OpenCode Skills (wps-excel/word/ppt/office)
 │   └── README.md        # ⚠️ 必须先读：skills 修改流程
+├── agents/               # 自定义 Agents (wps-expert + 3 个子 agents)
 └── install-addons.js     # 一键安装脚本 (6 步)
 ```
+
+## WPS Agents 功能
+
+### Agents 定义位置
+- 全局 agents：`~/.config/opencode/agents/` (不被 git 跟踪)
+- 项目 agents：`.opencode/agents/` (如需要)
+
+### 现有 Agents
+| Agent | 角色 | 说明 |
+|-------|------|------|
+| wps-expert | primary | WPS Office 智能助手主 agent |
+| wps-word | subagent | Word 文档处理专家 |
+| wps-excel | subagent | Excel 数据处理专家 |
+| wps-ppt | subagent | PPT 演示文稿专家 |
+
+### 使用方式
+1. 在 WPS 侧边栏底部点击 **Agent** 按钮选择
+2. 消息中可用 `@wps-word`、`@wps-excel`、`@wps-ppt` 调用子 agents
+3. 发送消息时会自动传递 `agent` 参数到 OpenCode API
+
+### 修改 Agents
+1. 修改 `~/.config/opencode/agents/` 下的 `.md` 文件
+2. 重启 OpenCode 服务使配置生效
+3. （可选）复制到 `.opencode/agents/` 实现项目级配置
 
 ## AI 编程助手注意事项
 
 如果你是一个 AI 助手，正在修改本项目：
 1. **修改 skills** → 改 `skills/` → 运行 `node install-addons.js` → git commit
 2. **修改 MCP** → 改 `wps-office-mcp/src/` → `npm run build` → git commit
-3. **重要：永远不要修改以下目录**（它们是安装产物，不是源文件）：
+3. **修改 Agents** → 改 `~/.config/opencode/agents/` → 重启服务 → git commit
+4. **重要：永远不要修改以下目录**（它们是安装产物，不是源文件）：
    - ❌ `~/.opencode/skills/` 或 `%USERPROFILE%\.opencode\skills\`
    - ❌ `%APPDATA%\kingsoft\wps\jsaddons\`
    - ❌ `~/.config/opencode/opencode.json`
-4. **每次修改后**检查：`git status` 确保修改已提交
+5. **每次修改后**检查：`git status` 确保修改已提交
+
+## Launcher 服务管理
+
+OpenCode 通过 Launcher 进程管理自动启动：
+- Launcher 监听：`http://127.0.0.1:14097`
+- API 端点：
+  - `GET /status` - 查看状态
+  - `POST /start` - 启动服务 (body: `{"cwd": "目录"}`)
+  - `POST /stop` - 停止服务
 
 ## 如何避免"改错目录"的问题
 
@@ -56,10 +92,11 @@ opencode-wps/
 ## 常见问题
 1. MCP 连不上 → `cd wps-office-mcp && npm install && npm run build`
 2. WPS 插件不显示 → 检查 `%APPDATA%\kingsoft\wps\jsaddons\opencode-wps_` 目录
-3. OpenCode 服务未启动 → `schtasks /Run /TN "OpenCodeServer"`
+3. OpenCode 服务未启动 → `schtasks /Run /TN "OpenCodeLauncher"` 或通过 Launcher API 启动
 4. 文件路径 → 始终用绝对路径
 5. WPS 必须运行才能进行 MCP 操作
 6. Skills 不生效 → 检查是否运行了 `node install-addons.js` 同步
+7. Agents 不显示 → 重启 OpenCode 服务让新 agents 生效
 
 ## 参考文档
 - README.md — 完整项目文档

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ OpenCode WPS 将 OpenCode AI 的能力集成到 WPS Office 中，通过侧边栏
 - **WPS 内嵌 AI 对话** — 侧边栏 Chat UI，支持 SSE 流式输出、Markdown 渲染
 - **多会话管理** — 创建、重命名、切换、删除对话会话
 - **MCP 工具集成** — 通过 WPS Office MCP 服务器，AI 可以直接操作文档（读/写/格式化）
+- **WPS 专用 Agents** — 自定义 wps-expert 主 agent 和 wps-word/wps-excel/wps-ppt 子 agents
+- **Agent 选择** — 底部工具栏支持切换不同 agent，消息自动传递 agent 参数
 - **一键安装** — 运行 `node install-addons.js` 自动完成全部组件安装
 - **开机自启** — 通过 Windows 计划任务自动启动 OpenCode 服务，无需手动操作
 
@@ -116,6 +118,26 @@ node install-addons.js
 - **发送消息** — 在输入框输入问题，按 Enter 或点击发送
 - **SSE 流式输出** — AI 回复实时流式显示，支持 Markdown 渲染（代码块、表格、列表等）
 - **会话管理** — 点击会话列表切换对话，支持创建、重命名、删除会话
+- **Agent 选择** — 点击底部工具栏的 Agent 按钮，选择不同的 AI 助手
+
+### WPS Agents
+
+项目内置了专门的 WPS Office 智能助手：
+
+| Agent | 类型 | 说明 |
+|-------|------|------|
+| **wps-expert** | 主 agent | WPS Office 智能助手，综合处理 Word/Excel/PPT |
+| **wps-word** | 子 agent | Word 文档处理专家（可用 `@wps-word` 调用）|
+| **wps-excel** | 子 agent | Excel 数据处理专家（可用 `@wps-excel` 调用）|
+| **wps-ppt** | 子 agent | PPT 演示文稿专家（可用 `@wps-ppt` 调用）|
+
+**使用方式**：
+1. 点击底部 **Agent** 按钮选择主 agent（默认 wps-expert）
+2. 在消息中使用 `@wps-word`、`@wps-excel`、`@wps-ppt` 调用子 agents 处理特定任务
+
+**自定义 Agents**：
+- Agents 定义位置：`~/.config/opencode/agents/`
+- 修改后重启 OpenCode 服务生效
 
 ### OpenCode 服务管理
 


### PR DESCRIPTION
## Summary

为 WPS 侧边栏添加 Agent 选择功能，集成专门的 WPS Office 智能助手。

## Changes

### 新增功能
- 添加 Agent 下拉选择按钮到底部工具栏
- 支持选择 wps-expert 作为默认主 agent  
- 创建 wps-word/wps-excel/wps-ppt 三个子 agents
- 发送消息时自动传递 agent 参数到 OpenCode API

### 使用方式
1. 点击 WPS 侧边栏底部的 Agent 按钮选择主 agent
2. 默认选择 wps-expert
3. 可用 @wps-word、@wps-excel、@wps-ppt 调用子 agents