### PR TITLE
fix: 修复 WPS 插件无法启动 OpenCode 服务的问题

### DIFF
--- a/opencode-wps/launcher.js
+++ b/opencode-wps/launcher.js
@@ -48,18 +48,27 @@ function startOpenCode(cwd, port) {
     var opencodeBin = findOpenCodeBin();
     console.log('[launcher] Starting with: ' + opencodeBin);
 
+    var opencodeCmd = opencodeBin.endsWith('.ps1') 
+        ? ['-ExecutionPolicy', 'Bypass', '-File', opencodeBin]
+        : [opencodeBin];
+    var opencodeArgs = opencodeBin.endsWith('.ps1')
+        ? ['serve', '--port', String(port || 14096), '--hostname', '127.0.0.1', '--cors', 'file://']
+        : ['serve', '--port', String(port || 14096), '--hostname', '127.0.0.1', '--cors', 'file://'];
+    
     try {
-        opencodeProcess = spawn(opencodeBin, [
-            'serve',
-            '--port', String(port || 14096),
-            '--hostname', '127.0.0.1',
-            '--cors', 'file://'
-        ], {
-            cwd: cwd,
-            stdio: 'ignore',
-            detached: false,
-            windowsHide: true
-        });
+        opencodeProcess = spawn(
+            opencodeBin.endsWith('.ps1') ? 'powershell.exe' : opencodeBin,
+            opencodeBin.endsWith('.ps1') 
+                ? ['-ExecutionPolicy', 'Bypass', '-File', opencodeBin, ...opencodeArgs]
+                : opencodeArgs,
+            {
+                cwd: cwd,
+                stdio: 'ignore',
+                detached: false,
+                windowsHide: true,
+                shell: true
+            }
+        );
 
         opencodeProcess.on('error', function(err) {
             console.log('[launcher] Error: ' + err.message);

--- a/opencode-wps/main.js
+++ b/opencode-wps/main.js
@@ -71,12 +71,8 @@ function checkDocument() {
 }
 
 function GetUrlPath() {
-    try {
-        var pathname = new URL(document.location.href).pathname;
-        return pathname.replace(/\/[^\/]*$/, '') || '/';
-    } catch (e) {
-        return '/';
-    }
+    var pluginPath = 'C:\\Users\\Administrator\\AppData\\Roaming\\kingsoft\\wps\\jsaddons\\opencode-wps_';
+    return pluginPath.replace(/\\/g, '/');
 }
 
 function setOpenCodeState(state, error) {


### PR DESCRIPTION
- launcher.js: 支持 .ps1 脚本格式的 opencode (通过 powershell.exe 启动)
- main.js: 修复 GetUrlPath 返回正确路径