### PR TITLE
feat: chat 模型选取改进

### DIFF
--- a/opencode-wps/taskpane.html
+++ b/opencode-wps/taskpane.html
@@ -833,14 +833,11 @@ function toggleModelDropdown(e) {
 }
 function selectModel(id) { CURRENT_MODEL = id; $modelName.textContent = id; closeAllDropdowns() }
 var RECOMMENDED_MODELS = [
-    { id: 'opencode/gpt-5-nano', name: 'GPT-5 Nano', providerID: 'opencode', free: true },
+    { id: 'opencode/deepseek-v4-flash-free', name: 'DeepSeek V4 Flash Free', providerID: 'opencode', free: true },
+    { id: 'opencode/qwen3.6-plus-free', name: 'Qwen 3.6 Plus Free', providerID: 'opencode', free: true },
     { id: 'opencode/minimax-m2.5-free', name: 'MiniMax M2.5 Free', providerID: 'opencode', free: true },
     { id: 'opencode/big-pickle', name: 'Big Pickle', providerID: 'opencode', free: true },
-    { id: 'opencode/ling-2.6-flash-free', name: 'Ling 2.6 Flash Free', providerID: 'opencode', free: true },
-    { id: 'opencode/hy3-preview-free', name: 'Hy3 preview Free', providerID: 'opencode', free: true },
-    { id: 'opencode/nemotron-3-super-free', name: 'Nemotron 3 Super Free', providerID: 'opencode', free: true },
-    { id: 'opencode/gpt-5.1-codex', name: 'GPT-5.1 Codex (Zen)', providerID: 'opencode', free: false },
-    { id: 'opencode/gpt-5-codex', name: 'GPT-5 Codex (Go)', providerID: 'opencode', free: false }
+    { id: 'opencode/nemotron-3-super-free', name: 'Nemotron 3 Super Free', providerID: 'opencode', free: true }
 ]
 var RECOMMENDED_PROVIDERS = [
     { id: 'opencode', name: 'OpenCode', models: RECOMMENDED_MODELS },
@@ -1194,7 +1191,7 @@ function handleSSEEvent(data) {
             if (props.info && props.info.role === 'assistant' && !props.info.finish) {
                 STREAMING_MSG_ID = props.info.id; STREAMING_TEXT = ''; STREAMING_REASONING = ''; STREAMING_TEXT_PART_ID = ''; STREAMING_REASONING_PART_ID = ''
                 ensureStreamingBubble()
-                if (props.info.modelID) { CURRENT_MODEL = props.info.modelID; $modelName.textContent = CURRENT_MODEL }
+                if (props.info.modelID && !CURRENT_MODEL) { CURRENT_MODEL = props.info.modelID; $modelName.textContent = CURRENT_MODEL }
             }
             if (props.info && props.info.role === 'assistant' && props.info.finish) finalizeStreaming()
             break
@@ -1261,6 +1258,10 @@ function sendMessage() {
         if (CURRENT_MODE && CURRENT_MODE !== 'build') body.mode = CURRENT_MODE
         if (CURRENT_LEVEL && CURRENT_LEVEL !== 'balanced') body.level = CURRENT_LEVEL
         if (CURRENT_AGENT) body.agent = CURRENT_AGENT
+        if (CURRENT_MODEL && CURRENT_MODEL.includes('/')) {
+            var parts = CURRENT_MODEL.split('/')
+            body.model = { providerID: parts[0], modelID: parts.slice(1).join('/') }
+        }
         postMessage('/session/' + SESSION_ID + '/message', body, function(s, t) { addSystemMessage('Error: ' + (t || 'status ' + s)); finalizeStreaming() })
     })
 }


### PR DESCRIPTION
## 概述

修复 WPS 插件 Chat 侧边栏模型选取的 3 个问题：

### 修复内容

| # | 问题 | 修复 |
|---|------|------|
| 1 | 发消息时 `model` 传字符串导致报错 `Expected object | null` | 改为 `{ providerID, modelID }` 对象格式 |
| 2 | 选模型后发消息，模型显示跳回 `minimax-m2.5` | 收 SSE 时加 `&& !CURRENT_MODEL` guard，不再无条件覆盖用户选择 |
| 3 | 模型列表含失效模型（GPT-5 Nano、Ling 2.6 Flash、Hy3、GPT-5.1 Codex、GPT-5 Codex） | 更新为当前有效免费模型：DeepSeek V4 Flash Free、Qwen 3.6 Plus Free、MiniMax M2.5 Free、Big Pickle、Nemotron 3 Super Free |

### 变更文件

- `opencode-wps/taskpane.html` — 3 处修改