### PR TITLE
feat: 默认模型切换为 DeepSeek V4 Flash Free

### DIFF
--- a/agents/wps-expert.md
+++ b/agents/wps-expert.md
@@ -1,7 +1,7 @@
 ---
 description: WPS Office 智能助手，专门帮助用户操作 WPS 文字、表格、演示文档
 mode: primary
-model: opencode/minimax-m2.5-free
+model: opencode/deepseek-v4-flash-free
 color: "#2563eb"
 ---
 


### PR DESCRIPTION
## 概述

将 wps-expert agent 的默认模型从 `opencode/minimax-m2.5-free` 切换到 `opencode/deepseek-v4-flash-free`。

### 变更

| 文件 | 改前 | 改后 |
|------|------|------|
| `agents/wps-expert.md` | `model: opencode/minimax-m2.5-free` | `model: opencode/deepseek-v4-flash-free` |

### 说明

- DeepSeek V4 Flash Free 已在模型列表第一项（`RECOMMENDED_MODELS[0]`），Chat 默认选中它
- Agent 层面也需要同步配置，否则 OpenCode 服务端可能仍用 MiniMax
- 已同步到 `~/.config/opencode/agents/` 和 `~/.opencode/agents/`