### PR TITLE
fix(install): enable et plugin in authaddin.json

### DIFF
--- a/install-addons.js
+++ b/install-addons.js
@@ -205,8 +205,6 @@ console.log('  已更新 jsplugins.xml');
 
 // 更新 authaddin.json（真正的启用开关）
 const authaddinJsonPath = path.join(jsaddonsDir, 'authaddin.json');
-const OPENCODE_KEY = '6b7a57516c426c6551796e326633317a';
-const OPENCODE_MD5 = '434c5765474f626a50724b30326674625070697a765758543735495461733635556e3432425f47532d33303d';
 
 if (fsEx.existsSync(authaddinJsonPath)) {
     try {
@@ -215,10 +213,16 @@ if (fsEx.existsSync(authaddinJsonPath)) {
         
         // 遍历所有应用类型（wps, et, wpp）
         ['wps', 'et', 'wpp'].forEach(appType => {
-            if (authData[appType] && authData[appType][OPENCODE_KEY]) {
-                authData[appType][OPENCODE_KEY].enable = true;
-                console.log('  已启用 ' + appType + ' 插件');
-            }
+            if (!authData[appType]) return;
+            // 遍历所有 key，按 name 字段匹配 opencode-wps（不依赖硬编码 key）
+            Object.keys(authData[appType]).forEach(key => {
+                if (key === 'namelist') return;
+                const entry = authData[appType][key];
+                if (entry && entry.name === 'opencode-wps') {
+                    entry.enable = true;
+                    console.log('  已启用 ' + appType + ' 插件');
+                }
+            });
         });
         
         fs.writeFileSync(authaddinJsonPath, JSON.stringify(authData, null, 4) + '\n', 'utf-8');


### PR DESCRIPTION
## 问题

Excel 中不显示 OpenCode 插件。根因是 \uthaddin.json\ 中 \t\ 条目的 \nable\ 为 \alse\，且安装脚本使用硬编码的 \OPENCODE_KEY\ 查找条目——该 key 与 WPS 实际生成的 key 不匹配，导致脚本无法启用 \t\ 插件。

## 修复

\install-addons.js\: 改为遍历所有 key，按 \
ame === 'opencode-wps'\ 字段匹配，不再依赖硬编码 key。这样无论 WPS 生成什么 key，都能正确启用插件。

## 验证

重装后 \uthaddin.json\ 中三种应用均显示 \nable: true\。