### PR TITLE
fix: address 5 review issues on pr-fixes branch

### DIFF
--- a/wps-office-mcp/scripts/wps-com.ps1
+++ b/wps-office-mcp/scripts/wps-com.ps1
@@ -1109,27 +1109,29 @@ switch ($Action) {
     "exportChartAsImage" {
         $excel = Get-WpsExcel
         if ($null -eq $excel) { Output-Json @{ success = $false; error = "WPS Excel not running" }; exit }
-        $sheet = if ($p.sheet) { $excel.ActiveWorkbook.Sheets.Item($p.sheet) } else { $excel.ActiveSheet }
+        $wb = $excel.ActiveWorkbook
+        if ($null -eq $wb) { Output-Json @{ success = $false; error = "No active workbook" }; exit }
+        $sheet = if ($p.sheet) { $wb.Sheets.Item($p.sheet) } else { $excel.ActiveSheet }
         $outputPath = if ($p.outputPath) { $p.outputPath } else { $p.path }
         if ([string]::IsNullOrEmpty($outputPath)) { Output-Json @{ success = $false; error = "Missing outputPath" }; exit }
         $chartName = $p.chartName
         if ([string]::IsNullOrEmpty($chartName)) { Output-Json @{ success = $false; error = "Missing chartName" }; exit }
         $rawFormat = if ($p.format) { $p.format.ToString().ToUpper() } else { "PNG" }
-        $filterName = if ($rawFormat -eq "JPEG") { "JPG" } else { $rawFormat }
         $chartObj = $sheet.ChartObjects($chartName)
-        $chartObj.Chart.Export($outputPath, $filterName)
-        Output-Json @{ success = $true; data = @{ chartName = $chartName; outputPath = $outputPath; format = $filterName } }
+        $chartObj.Chart.Export($outputPath, $rawFormat)
+        Output-Json @{ success = $true; data = @{ chartName = $chartName; outputPath = $outputPath; format = $rawFormat } }
     }
 
     "exportRangeAsImage" {
         $excel = Get-WpsExcel
         if ($null -eq $excel) { Output-Json @{ success = $false; error = "WPS Excel not running" }; exit }
-        $sheet = if ($p.sheet) { $excel.ActiveWorkbook.Sheets.Item($p.sheet) } else { $excel.ActiveSheet }
+        $wb = $excel.ActiveWorkbook
+        if ($null -eq $wb) { Output-Json @{ success = $false; error = "No active workbook" }; exit }
+        $sheet = if ($p.sheet) { $wb.Sheets.Item($p.sheet) } else { $excel.ActiveSheet }
         $outputPath = if ($p.outputPath) { $p.outputPath } else { $p.path }
         if ([string]::IsNullOrEmpty($outputPath)) { Output-Json @{ success = $false; error = "Missing outputPath" }; exit }
         if ([string]::IsNullOrEmpty($p.range)) { Output-Json @{ success = $false; error = "Missing range" }; exit }
         $rawFormat = if ($p.format) { $p.format.ToString().ToUpper() } else { "PNG" }
-        $filterName = if ($rawFormat -eq "JPEG") { "JPG" } else { $rawFormat }
         $range = $sheet.Range($p.range)
         $tempChart = $null
         try {
@@ -1137,10 +1139,10 @@ switch ($Action) {
             $tempChart = $sheet.ChartObjects().Add(0, 0, $range.Width, $range.Height)
             $tempChart.Activate()
             $tempChart.Chart.Paste()
-            $tempChart.Chart.Export($outputPath, $filterName)
+            $tempChart.Chart.Export($outputPath, $rawFormat)
             $tempChart.Delete()
             $tempChart = $null
-            Output-Json @{ success = $true; data = @{ range = $p.range; outputPath = $outputPath; format = $filterName } }
+            Output-Json @{ success = $true; data = @{ range = $p.range; outputPath = $outputPath; format = $rawFormat } }
         } catch {
             if ($null -ne $tempChart) { try { $tempChart.Delete() } catch {} }
             Output-Json @{ success = $false; error = "导出区域为图片失败: $($_.Exception.Message)" }

--- a/wps-office-mcp/src/tools/excel/chart.ts
+++ b/wps-office-mcp/src/tools/excel/chart.ts
@@ -703,14 +703,14 @@ export const exportRangeAsImageHandler: ToolHandler = async (
   };
 
   // 校验 range 格式（与 createChart 保持一致）
-  if (!range || !/^[A-Z]+[0-9]+(:[A-Z]+[0-9]+)?$/i.test(range)) {
+  if (!range || !/^\$?[A-Z]+\$?\d+(:\$?[A-Z]+\$?\d+)?$/i.test(range)) {
     return {
       id: uuidv4(),
       success: false,
       content: [
         {
           type: 'text',
-          text: `区域格式无效，应为类似 A1:F20 的格式，当前传入: ${range}`,
+          text: `区域格式无效，应为类似 A1:F20 或 $A$1:$B$2 的格式，当前传入: ${range}`,
         },
       ],
       error: '区域格式无效',

--- a/wps-office-mcp/src/utils/logger.ts
+++ b/wps-office-mcp/src/utils/logger.ts
@@ -8,6 +8,7 @@
 
 import winston from 'winston';
 import path from 'path';
+import fs from 'fs';
 
 /**
  * 日志级别枚举
@@ -41,6 +42,9 @@ const isEnvTrue = (value?: string): boolean => {
 const createLogger = (name: string): winston.Logger => {
   const homeDir = process.env.HOME || process.env.USERPROFILE || require('os').homedir();
   const logDir = path.join(homeDir, '.wps-office-mcp', 'logs');
+  if (!fs.existsSync(logDir)) {
+    fs.mkdirSync(logDir, { recursive: true });
+  }
   // MCP 默认走 stdio 协议，stdout 必须保持纯净；仅在显式开启时才输出 Console 日志
   const enableConsoleLog = isEnvTrue(process.env.MCP_CONSOLE_LOG);
   const transports: winston.transport[] = [


### PR DESCRIPTION
## 代码审查修复

修复 `pr-fixes` 分支代码审查发现的 5 个问题：

| # | 严重度 | 文件 | 问题 | 修复 |
|---|--------|------|------|------|
| 1 | 高 | `logger.ts:43` | 日志目录未创建，Winston File transport 首次运行因 `ENOENT` 崩溃 | 添加 `mkdirSync({ recursive: true })` |
| 2 | 高 | `wps-com.ps1` | `exportChartAsImage`/`exportRangeAsImage` 缺少 `ActiveWorkbook` null 检查 | 添加 `$wb = $excel.ActiveWorkbook` + null guard |
| 3 | 中 | `chart.ts:706` | range 正则不支持 `$A$1:$B$2` 绝对引用格式 | 正则添加 `\$?` 支持可选 `$` 前缀 |
| 4 | 低 | `wps-com.ps1` | JPEG→JPG 归一化在 TS 和 PS1 重复（PS1 层死代码） | 移除 PS1 层冗余归一化 |
| 5 | 低 | `main.js` (macOS) | `setSlideBackground` 的 `color`/`imagePath` 未互斥 | 改为 `if/else if` 结构 |

编译通过。
