### PR TITLE
fix: GetUrlPath hardcodes Administrator username causing blank sidebar

### DIFF
--- a/agents/wps-expert.md
+++ b/agents/wps-expert.md
@@ -1,6 +1,6 @@
 ---
 description: WPS Office 智能助手，专门帮助用户操作 WPS 文字、表格、演示文档
-mode: primary
+mode: subagent
 model: opencode/deepseek-v4-flash-free
 color: "#2563eb"
 ---

--- a/install-addons.js
+++ b/install-addons.js
@@ -126,6 +126,16 @@ addons.forEach(addon => {
     });
 
     console.log('    已复制 ' + copiedCount + ' 个文件');
+
+    // 动态注入安装路径（修复硬编码路径问题）
+    const mainJsPath = path.join(destDir, 'main.js');
+    if (fsEx.existsSync(mainJsPath)) {
+        const mainJsContent = fs.readFileSync(mainJsPath, 'utf-8');
+        const actualPath = destDir.replace(/\\/g, '\\\\');
+        const updatedContent = mainJsContent.replace('___ADDON_INSTALL_PATH___', actualPath);
+        fs.writeFileSync(mainJsPath, updatedContent, 'utf-8');
+        console.log('    已注入安装路径: ' + destDir);
+    }
 });
 
 // 清理已合并的旧插件

--- a/opencode-wps/main.js
+++ b/opencode-wps/main.js
@@ -73,7 +73,7 @@ function checkDocument() {
 }
 
 function GetUrlPath() {
-    var pluginPath = 'C:\\Users\\Administrator\\AppData\\Roaming\\kingsoft\\wps\\jsaddons\\opencode-wps_';
+    var pluginPath = '___ADDON_INSTALL_PATH___';
     return pluginPath.replace(/\\/g, '/');
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-wps",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-wps",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "fs-extra": "^8.1.0"


### PR DESCRIPTION
## Problem

`main.js` `GetUrlPath()` hardcoded the `Administrator` username. When the actual Windows user is different, `CreateTaskPane` loads a non-existent file path, resulting in a blank sidebar.

## Fix

- `main.js`: Replace hardcoded path with placeholder `___ADDON_INSTALL_PATH___`
- `install-addons.js`: Auto-inject the correct user-specific install path during installation (`%APPDATA%\kingsoft\wps\jsaddons\opencode-wps_`)

## Verification

Run `node install-addons.js`, then check the installed `main.js` - `GetUrlPath()` now contains the correct current user path.