### PR TITLE
fix: GetUrlPath 硬编码用户名导致侧边栏空白（基于 #39 的 review 改进）

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -50,9 +50,10 @@ WPS 的 taskpane 是特殊的运行环境，document 对象和浏览器不一致
 
 1. **taskpane 中使用绝对路径**
    ```javascript
-   // 正确代码 - 硬编码插件目录
+   // 正确代码 - 安装时动态注入路径
    function GetUrlPath() {
-       return 'file:///C:/Users/Administrator/AppData/Roaming/kingsoft/wps/jsaddons/opencode-wps_';
+       var pluginPath = '___WPS_ADDON_PATH___'; // install-addons.js 替换为实际路径
+       return pluginPath.replace(/\\/g, '/');
    }
    ```
 

--- a/install-addons.js
+++ b/install-addons.js
@@ -133,7 +133,7 @@ addons.forEach(addon => {
         if (fsEx.existsSync(mainJsPath)) {
             const mainJsContent = fs.readFileSync(mainJsPath, 'utf-8');
             const actualPath = destDir.replace(/\\/g, '\\\\');
-            const updatedContent = mainJsContent.replace(/___WPS_ADDON_PATH___/g, actualPath);
+            const updatedContent = mainJsContent.replace(/___WPS_ADDON_PATH___/g, () => actualPath);
             if (updatedContent === mainJsContent) {
                 console.log('    [警告] main.js 中未找到 ___WPS_ADDON_PATH___，路径注入失败');
             } else {

--- a/install-addons.js
+++ b/install-addons.js
@@ -128,13 +128,19 @@ addons.forEach(addon => {
     console.log('    已复制 ' + copiedCount + ' 个文件');
 
     // 动态注入安装路径（修复硬编码路径问题）
-    const mainJsPath = path.join(destDir, 'main.js');
-    if (fsEx.existsSync(mainJsPath)) {
-        const mainJsContent = fs.readFileSync(mainJsPath, 'utf-8');
-        const actualPath = destDir.replace(/\\/g, '\\\\');
-        const updatedContent = mainJsContent.replace('___ADDON_INSTALL_PATH___', actualPath);
-        fs.writeFileSync(mainJsPath, updatedContent, 'utf-8');
-        console.log('    已注入安装路径: ' + destDir);
+    if (addon.name === 'opencode-wps') {
+        const mainJsPath = path.join(destDir, 'main.js');
+        if (fsEx.existsSync(mainJsPath)) {
+            const mainJsContent = fs.readFileSync(mainJsPath, 'utf-8');
+            const actualPath = destDir.replace(/\\/g, '\\\\');
+            const updatedContent = mainJsContent.replace('___WPS_ADDON_PATH___', actualPath);
+            if (updatedContent === mainJsContent) {
+                console.warn('    [警告] main.js 中未找到 ___WPS_ADDON_PATH___，路径注入失败');
+            } else {
+                fs.writeFileSync(mainJsPath, updatedContent, 'utf-8');
+                console.log('    已注入安装路径: ' + destDir);
+            }
+        }
     }
 });
 

--- a/install-addons.js
+++ b/install-addons.js
@@ -133,9 +133,9 @@ addons.forEach(addon => {
         if (fsEx.existsSync(mainJsPath)) {
             const mainJsContent = fs.readFileSync(mainJsPath, 'utf-8');
             const actualPath = destDir.replace(/\\/g, '\\\\');
-            const updatedContent = mainJsContent.replace('___WPS_ADDON_PATH___', actualPath);
+            const updatedContent = mainJsContent.replace(/___WPS_ADDON_PATH___/g, actualPath);
             if (updatedContent === mainJsContent) {
-                console.warn('    [警告] main.js 中未找到 ___WPS_ADDON_PATH___，路径注入失败');
+                console.log('    [警告] main.js 中未找到 ___WPS_ADDON_PATH___，路径注入失败');
             } else {
                 fs.writeFileSync(mainJsPath, updatedContent, 'utf-8');
                 console.log('    已注入安装路径: ' + destDir);

--- a/install-addons.js
+++ b/install-addons.js
@@ -141,6 +141,20 @@ addons.forEach(addon => {
                 console.log('    已注入安装路径: ' + destDir);
             }
         }
+
+        // 注入用户主目录到 config.js（修复 CWD 硬编码问题）
+        const configJsPath = path.join(destDir, 'config.js');
+        if (fsEx.existsSync(configJsPath)) {
+            const configJsContent = fs.readFileSync(configJsPath, 'utf-8');
+            const userHome = process.env.USERPROFILE || require('os').homedir();
+            const updatedConfig = configJsContent.replace(/___WPS_USER_HOME___/g, () => userHome.replace(/\\/g, '\\\\'));
+            if (updatedConfig === configJsContent) {
+                console.log('    [警告] config.js 中未找到 ___WPS_USER_HOME___，用户目录注入失败');
+            } else {
+                fs.writeFileSync(configJsPath, updatedConfig, 'utf-8');
+                console.log('    已注入用户目录: ' + userHome);
+            }
+        }
     }
 });
 

--- a/opencode-wps/config.js
+++ b/opencode-wps/config.js
@@ -35,7 +35,9 @@ var CONFIG = {
         // 加载项名称
         addonName: 'OpenCode AI',
         // 插件版本
-        version: '1.1.0'
+        version: '1.1.0',
+        // 用户主目录（安装时注入，见 install-addons.js）
+        userHome: '___WPS_USER_HOME___'
     },
 
     // 会话配置

--- a/opencode-wps/launcher.js
+++ b/opencode-wps/launcher.js
@@ -3,6 +3,7 @@ var http = require('http');
 var { spawn, exec } = require('child_process');
 var path = require('path');
 var fs = require('fs');
+var os = require('os');
 
 var PORT = 14097;
 var opencodeProcess = null;
@@ -241,8 +242,8 @@ function findOpenCodeBin() {
 
     // 2. 尝试常见安装路径
     var commonPaths = [
-        path.join(process.env.USERPROFILE || 'C:\\Users\\Administrator', '.trae-cn', 'bin', 'opencode.exe'),
-        path.join(process.env.LOCALAPPDATA || 'C:\\Users\\Administrator\\AppData\\Local', 'Programs', 'opencode', 'opencode.exe'),
+        path.join(process.env.USERPROFILE || os.homedir(), '.trae-cn', 'bin', 'opencode.exe'),
+        path.join(process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local'), 'Programs', 'opencode', 'opencode.exe'),
         'C:\\Program Files\\opencode\\opencode.exe',
         'C:\\Program Files (x86)\\opencode\\opencode.exe'
     ];

--- a/opencode-wps/main.js
+++ b/opencode-wps/main.js
@@ -73,7 +73,7 @@ function checkDocument() {
 }
 
 function GetUrlPath() {
-    var pluginPath = '___ADDON_INSTALL_PATH___';
+    var pluginPath = '___WPS_ADDON_PATH___';
     return pluginPath.replace(/\\/g, '/');
 }
 

--- a/opencode-wps/taskpane.html
+++ b/opencode-wps/taskpane.html
@@ -607,7 +607,7 @@ function confirmCwdChange() {
 function startOpenCode() {
     // 如果用户输入了目录就用用户输入的，否则用用户目录
     var userInput = $setupCwd.value.replace(/\\/g, '\\\\').trim()
-    var cwd = userInput || 'C:\\Users\\' + 'Administrator'
+    var cwd = userInput || CONFIG.plugin.userHome
 
     // 保存 CWD 到历史
     addCwdHistory(cwd)


### PR DESCRIPTION
## 背景

此 PR 基于 #39 的代码审查结果，对其修改进行了进一步优化。

## 关联

- 修复 Issue: #35（侧边栏空白）
- 原始 PR: #39（helloworldbugs 的初始修复）

## 修改内容

### 原始修改（来自 #39）

| 文件 | 修改 |
|------|------|
| \opencode-wps/main.js\ | 将硬编码路径 \C:\\\\Users\\\\Administrator\\\\...\ 替换为占位符 |
| \install-addons.js\ | 安装时动态注入实际路径 |

### Review 改进（本 PR）

1. **注入失败警告** — 如果占位符未找到，打印警告而非静默跳过（防止占位符缺失导致侧边栏仍然空白）
2. **安全的占位符命名** — \___ADDON_INSTALL_PATH___\ → \___WPS_ADDON_PATH___\，减少命名冲突风险
3. **限定执行范围** — 路径注入只在 \opencode-wps\ 插件上执行，不影响其他 addon

## 验收

\\\ash
node install-addons.js
\\\

检查安装后的 \%APPDATA%\\\\kingsoft\\\\wps\\\\jsaddons\\\\opencode-wps_\\\\main.js\，\GetUrlPath()\ 应包含当前用户的实际路径。